### PR TITLE
Update hdmi_cec.markdown

### DIFF
--- a/source/_components/hdmi_cec.markdown
+++ b/source/_components/hdmi_cec.markdown
@@ -39,6 +39,13 @@ For the default virtual environment of a [Raspberry Pi All-In-One installation](
 $ ln -s /usr/local/lib/python3.4/dist-packages/cec /srv/hass/hass_venv/lib/python3.4/site-packages
 ```
 
+For the default virtual environment of a [Manual installation](/getting-started/installation-raspberry-pi/) the command would be as follows.
+
+```bash
+$ ln -s /usr/local/lib/python3.4/site-packages/cec /srv/hass/hass_venv/lib/python3.4/site-packages
+```
+
+
 <p class='note'>If after symlinking and adding `hdmi_cec:` to your configuration you are getting the following error in your logs, 
 `* failed to open vchiq instance` you will also need to add the user account Home Assistant runs under, to the `video` group. To add the Home Assistant user account to the `video` group, run the following command. `$ usermod -a -G video <hass_user_account>`
 </p>


### PR DESCRIPTION
If we follow the instructions on raspberry, the install path is different after a manual build.

**Description:**


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

